### PR TITLE
Fix: prevent adding empty or whitespace-only todo items

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,5 +1,9 @@
 function add_todo(){
     const todoVal = document.getElementById("task").value;
+    if (!todoVal.trim()) {
+        alert("Task cannot be empty!");
+        return;
+    }
     // console.log(todoVal);
     const node = document.createElement("div");
     node.className = "list-group-item list-group-item-primary mb-2";


### PR DESCRIPTION
Currently, users can add empty tasks. This should be prevented with a validation check.

related issue: Closes #1