### PR TITLE
Fix: Avoid showing multiple edit inputs for the same todo

### DIFF
--- a/script.js
+++ b/script.js
@@ -37,9 +37,11 @@ function deleteTodo(e) {
 }
 
 function editTodo(e) {
-    console.log(e.target);
+    // console.log(e.target);
 
     const parentEle = e.target.parentElement;
+
+    if (parentEle.querySelector("#edit-todo")) return;
 
     const updateContainer = document.createElement("div");
     parentEle.appendChild(updateContainer);
@@ -66,7 +68,7 @@ function editTodo(e) {
 }
 
 function updateTodo(e) {
-    console.log(e.target);
+    // console.log(e.target);
 
     const parentEle = e.target.parentElement;
     const editTodoInput = parentEle.querySelector("#edit-todo");


### PR DESCRIPTION
## 📝 Pull Request Description

**What does this PR do?**
Currently, if a user clicks the "Edit" button multiple times, multiple edit input fields are appended to the same todo item. This leads to a cluttered UI and unexpected behavior.

Fixes #2 

---

## ✅ Changes Made

- [x] Briefly describe what code changes were made
- [x] UI updates or behavior changes (if any)

---

## 🚦 Screenshots / GIFs (Optional)

![image](https://github.com/user-attachments/assets/bb18862e-c961-47b3-9a75-d73205a073c3)

---

## 🔍 Testing Done

- [x] Manually tested
- [ ] Added/updated related test cases
- [x] No breaking changes observed

---

## 📌 Checklist

- [x] Linked to relevant issue(s)
- [x] Added meaningful commit message(s)
- [x] Code follows project coding style
- [x] Ready for review

---

> PR submitted by: @trilok2703
